### PR TITLE
update katex version

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     },
     "license": "MIT",
     "dependencies": {
-        "katex": "^0.8.3"
+        "katex": "^0.9.0"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1924,11 +1924,11 @@ jsx-ast-utils@^2.0.0:
   dependencies:
     array-includes "^3.0.3"
 
-katex@^0.8.3:
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/katex/-/katex-0.8.3.tgz#909d99864baf964c3ccae39c4a99a8e0fb9a1bd0"
+katex@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/katex/-/katex-0.9.0.tgz#26a7d082c21d53725422d2d71da9b2d8455fbd4a"
   dependencies:
-    match-at "^0.1.0"
+    match-at "^0.1.1"
 
 kind-of@^3.0.2:
   version "3.2.2"
@@ -2033,7 +2033,7 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
-match-at@^0.1.0:
+match-at@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/match-at/-/match-at-0.1.1.tgz#25d040d291777704d5e6556bbb79230ec2de0540"
 


### PR DESCRIPTION
The version of katex set in the `yarn.lock` file causes some users issues during installation (see https://github.com/idyll-lang/idyll/issues/238 and https://github.com/idyll-lang/idyll/issues/239) for example. This PR simply bumps that dependency so this issue goes away.