### PR TITLE
Greater than fix

### DIFF
--- a/src/latex.js
+++ b/src/latex.js
@@ -6,9 +6,7 @@ import katex from "katex";
 import React from "react"; //eslint-disable-line
 import PropTypes from "prop-types";
 
-const latexString = (string, options) => {
-    // Remove potential HTML
-    string = string.replace(/(<([^>]+)>)/gi, "");
+const latexify = (string, options) => {
     const regularExpression = /\$\$[\s\S]+?\$\$|\\\[[\s\S]+?\\\]|\\\([\s\S]+?\\\)|\$[\s\S]+?\$/g;
     const blockRegularExpression = /\$\$[\s\S]+?\$\$|\\\[[\s\S]+?\\\]/g;
 
@@ -23,6 +21,7 @@ const latexString = (string, options) => {
     const renderLatexString = (s, t) => {
         let renderedString;
         try {
+            // returns HTML markup
             renderedString = katex.renderToString(
                 s,
                 t === "block" ? Object.assign(options, { displayMode: true }) : options
@@ -64,12 +63,13 @@ const latexString = (string, options) => {
             if (r.type === "text") {
                 return r.string;
             }
-            return renderLatexString(r.string, r.type);
+            return (<span dangerouslySetInnerHTML={{__html: renderLatexString(r.string, r.type)}} />);
         });
 
-        return newResult.join(" ");
+        return newResult;
     };
 
+    // Returns list of spans with latex and non-latex strings.
     return processResult(result);
 };
 
@@ -121,26 +121,23 @@ class Latex extends React.Component {
             strict,
             trust,
         } = this.props;
-        return (
-            <span
-                dangerouslySetInnerHTML={{
-                    __html: latexString(children, {
-                        displayMode,
-                        leqno,
-                        fleqn,
-                        throwOnError,
-                        errorColor,
-                        macros,
-                        minRuleThickness,
-                        colorIsTextColor,
-                        maxSize,
-                        maxExpand,
-                        strict,
-                        trust,
-                    }),
-                }}
-            />
-        );
+
+        const renderUs = latexify( children, {displayMode,
+            leqno,
+            fleqn,
+            throwOnError,
+            errorColor,
+            macros,
+            minRuleThickness,
+            colorIsTextColor,
+            maxSize,
+            maxExpand,
+            strict,
+            trust} );
+        renderUs.unshift(null);
+        renderUs.unshift('span'); //put everything in a span
+        // spread renderUs out to children args
+        return React.createElement.apply(null, renderUs)        
     }
 }
 

--- a/src/latex.js
+++ b/src/latex.js
@@ -24,7 +24,7 @@ const latexify = (string, options) => {
             // returns HTML markup
             renderedString = katex.renderToString(
                 s,
-                t === "block" ? Object.assign(options, { displayMode: true }) : options
+                t === "block" ? Object.assign({ displayMode: true }, options) : options
             );
         } catch (err) {
             console.error("couldn`t convert string", s);

--- a/test/index.js
+++ b/test/index.js
@@ -29,10 +29,25 @@ describe("react-latex", () => {
     it("Should have katex class", () => {
         const testString = ReactDomServer.renderToStaticMarkup(<Test />);
         assert.notEqual(-1, testString.indexOf("<span class=\"katex-mathml\">"));
+        assert.equal('a', testString);
     });
 
     // it("Should render string with brackets properly", () => {
     //     const testStringWithBrackets = ReactDomServer.renderToStaticMarkup(<TestBrackets />).trim();
     //     assert.equal(bracketString, testStringWithBrackets);
     // });
+});
+
+
+class TestLtGt extends React.Component {
+    render () {
+        return React.createElement(latex, null,  "compact size (< 20'), spectral types >M4");
+    }
+}
+
+describe("react-latex2", () => {
+    it("It should not mess up gt and lt", () => {
+        const testString = ReactDomServer.renderToStaticMarkup(<TestLtGt />);
+        assert.equal( testString, "<span>compact size (&lt; 20&#x27;), spectral types &gt;M4</span>");
+    });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -29,25 +29,44 @@ describe("react-latex", () => {
     it("Should have katex class", () => {
         const testString = ReactDomServer.renderToStaticMarkup(<Test />);
         assert.notEqual(-1, testString.indexOf("<span class=\"katex-mathml\">"));
-        assert.equal('a', testString);
     });
 
     // it("Should render string with brackets properly", () => {
     //     const testStringWithBrackets = ReactDomServer.renderToStaticMarkup(<TestBrackets />).trim();
     //     assert.equal(bracketString, testStringWithBrackets);
     // });
-});
 
-
-class TestLtGt extends React.Component {
-    render () {
-        return React.createElement(latex, null,  "compact size (< 20'), spectral types >M4");
-    }
-}
-
-describe("react-latex2", () => {
-    it("It should not mess up gt and lt", () => {
+    it("It should not strip gt and lt", () => {        
+        class TestLtGt extends React.Component {
+            render () {
+                return React.createElement(latex, null,  "compact size (< 20'), spectral types >M4");
+            }
+        }
         const testString = ReactDomServer.renderToStaticMarkup(<TestLtGt />);
         assert.equal( testString, "<span>compact size (&lt; 20&#x27;), spectral types &gt;M4</span>");
     });
+
+    it("It should escape HTML tags outside of math", () => {        
+        class TestLtGt extends React.Component {
+            render () {
+                return React.createElement(latex, null,
+                    "compact size (<script>window.bad();</script> 20'), spectral $\\sqrt{8}$ types >M4");
+            }
+        }
+        const testString = ReactDomServer.renderToStaticMarkup(<TestLtGt />);
+        assert.equal(-1,  testString.indexOf("<script>window.bad();</script>"));
+    });
+    
+    it("It should escape HTML tags inside of math", () => {        
+        class TestLtGt extends React.Component {
+            render () {
+                return React.createElement(latex, null,  "compact size $<script>window.dobadstuff()</script>$");
+            }
+        }
+        const testString = ReactDomServer.renderToStaticMarkup(<TestLtGt />);
+        assert.equal(-1,  testString.indexOf("<script>window.dobadstuff()</script>"));
+    });
+
+    
 });
+


### PR DESCRIPTION
Fixes bug where the math includes text like "magnitudes < 20p and frequencies > 2f" got mangled.

Also fixes bug where a block display will cause all following math to be in block display mode.